### PR TITLE
Add CI config

### DIFF
--- a/.github/workflows/compile.yml
+++ b/.github/workflows/compile.yml
@@ -1,0 +1,19 @@
+name: CI
+
+on:
+  push:
+  pull_request:
+    branches: [ "main" ]
+  workflow_dispatch:
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v3
+
+      - name: Compile using gfortran
+        run: |
+          gfortran -Wall -Wextra -std=f2008 -o merge_sun_tables merge_sun_tables.f90
+          gfortran -Wall -Wextra -std=f2008 -o merge_galaxy_wind_tables merge_galaxy_wind_tables.f90


### PR DESCRIPTION
This adds a simple configuration to compile the two files in gfortran using GitHub actions. As expected, it currently fails to compile using gfortran.

(This is actually my first time using GitHub actions, so I don't know how "good" this configuration is, but it seems to work.)